### PR TITLE
ci: add PR/push CI workflow (and fix node 26 docker build)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,76 @@
+# Continuous integration for pull requests and pushes to main.
+# Runs the JS toolchain (typecheck, test, build) and verifies the Docker
+# images build — including the Node base image — without pushing or deploying.
+
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'assets/**'
+      - '.gitignore'
+      - 'LICENSE'
+      - 'CODE_OF_CONDUCT.md'
+      - 'CONTRIBUTING.md'
+
+# Cancel superseded runs on the same ref (e.g. successive pushes to a PR).
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-test:
+    name: typecheck · test · build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Test
+        run: pnpm test
+
+      - name: Build
+        run: pnpm build
+
+  docker-build:
+    name: docker build (no push)
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        image: [api, worker, migrate]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build ${{ matrix.image }} image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile.${{ matrix.image }}
+          push: false
+          cache-from: type=gha,scope=${{ matrix.image }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.image }}

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -1,7 +1,7 @@
 FROM node:26-alpine AS base
 
 # Install pnpm
-RUN corepack enable && corepack prepare pnpm@11.1.1 --activate
+RUN npm install -g pnpm@11.1.1
 
 WORKDIR /app
 
@@ -27,7 +27,7 @@ ARG APP_VERSION=""
 ENV COMMIT_SHA=${COMMIT_SHA}
 ENV APP_VERSION=${APP_VERSION}
 
-RUN corepack enable && corepack prepare pnpm@11.1.1 --activate
+RUN npm install -g pnpm@11.1.1
 
 WORKDIR /app
 

--- a/Dockerfile.migrate
+++ b/Dockerfile.migrate
@@ -3,7 +3,7 @@
 
 FROM node:26-alpine
 
-RUN corepack enable && corepack prepare pnpm@11.1.1 --activate
+RUN npm install -g pnpm@11.1.1
 
 WORKDIR /app
 

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -1,7 +1,7 @@
 FROM node:26-alpine AS base
 
 # Install pnpm
-RUN corepack enable && corepack prepare pnpm@11.1.1 --activate
+RUN npm install -g pnpm@11.1.1
 
 WORKDIR /app
 
@@ -22,7 +22,7 @@ RUN pnpm build --filter=@maritaca/core --filter=@maritaca/worker
 # Production stage
 FROM node:26-alpine AS production
 
-RUN corepack enable && corepack prepare pnpm@11.1.1 --activate
+RUN npm install -g pnpm@11.1.1
 
 WORKDIR /app
 


### PR DESCRIPTION
The repo had **no PR validation** — `deploy.yml` only runs on tags and goes straight to production, so every change (including the Dependabot bumps in #23–#28) had to be validated by hand locally.

This adds `.github/workflows/ci.yml`, triggered on `pull_request` and pushes to `main`:

- **build-test** — `pnpm install --frozen-lockfile`, then `typecheck`, `test`, `build` on the Node version pinned in `.nvmrc` (22), with pnpm store caching.
- **docker-build** — builds the `api`, `worker`, and `migrate` images (matrix, `push: false`, GHA layer cache) so Dockerfile / base-image changes are verified in CI before a release tag triggers a real deploy.

### The CI immediately earned its keep
On the first run, `build-test` passed but **all three docker builds failed** — `corepack enable` exited 127 because **Node 26 no longer bundles corepack** (removed in Node 25+). This is exactly the node 26-alpine image-build risk flagged in #28 that couldn't be verified locally (no Docker daemon).

Fixed in this PR by installing the pinned pnpm directly via `npm install -g pnpm@11.1.1` (npm is still bundled) across all five Dockerfile stages. The version still matches `packageManager`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)