### PR TITLE
feat(api): admin HTTP API to provision project API keys (#39)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,16 @@ PORT=7377
 HOST=0.0.0.0
 
 # =============================================================================
+# Admin API Configuration
+# =============================================================================
+# Bearer credential for the admin provisioning API (POST/GET/DELETE
+# /v1/admin/api-keys), which mints project-scoped API keys at runtime.
+# Distinct from project API keys so a normal key cannot create new projects.
+# When unset, all /v1/admin/* requests are rejected with 503 (admin API off).
+# Generate with: openssl rand -hex 32
+# ADMIN_API_KEY=your-admin-bearer-token
+
+# =============================================================================
 # Logging Configuration
 # =============================================================================
 

--- a/README.md
+++ b/README.md
@@ -378,6 +378,44 @@ Get message status and delivery events.
 
 Health check endpoint for load balancers.
 
+### Admin API — provisioning API keys
+
+Admin-only endpoints to mint project-scoped API keys at runtime (the automatable
+equivalent of `pnpm create-api-key`). Useful for multi-tenant consumers that
+provision **one Maritaca project / API key per downstream tenant** at onboarding
+— the architecturally-aligned way to isolate per-tenant integrations such as
+Slack (see [docs/slack-oauth.md](./docs/slack-oauth.md)).
+
+Gated behind a dedicated `ADMIN_API_KEY` bearer credential, distinct from
+project API keys, so a normal project key cannot create or revoke keys. When
+`ADMIN_API_KEY` is unset, every `/v1/admin/*` request is rejected with `503`.
+
+```bash
+# Create a key bound to a project — returns the plaintext key exactly once
+curl -X POST http://localhost:7377/v1/admin/api-keys \
+  -H "Authorization: Bearer $ADMIN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{ "projectId": "tenant-acme" }'
+# → 201 { "id", "projectId", "apiKey", "keyPrefix", "createdAt" }
+
+# List keys for a project (metadata only, never the secret)
+curl "http://localhost:7377/v1/admin/api-keys?projectId=tenant-acme" \
+  -H "Authorization: Bearer $ADMIN_API_KEY"
+
+# Revoke a key by id
+curl -X DELETE http://localhost:7377/v1/admin/api-keys/<id> \
+  -H "Authorization: Bearer $ADMIN_API_KEY"
+```
+
+| Endpoint | Description |
+|----------|-------------|
+| `POST /v1/admin/api-keys` | Create a key for `projectId`; returns the plaintext key once |
+| `GET /v1/admin/api-keys?projectId=…` | List a project's keys (no secret) |
+| `DELETE /v1/admin/api-keys/:id` | Revoke a key |
+
+Requests without the admin credential get `401` (missing/invalid header) or
+`403` (a non-admin bearer token, e.g. a project key).
+
 ## Compliance (GDPR/LGPD)
 
 Maritaca includes built-in compliance features:
@@ -442,6 +480,7 @@ All configuration is done via environment variables. See [.env.example](./.env.e
 | `DATABASE_URL` | Yes | PostgreSQL connection string |
 | `REDIS_URL` | Yes | Redis connection string |
 | `AUDIT_ENCRYPTION_KEY` | Production | PII encryption key (AES-256) |
+| `ADMIN_API_KEY` | For admin API | Bearer credential for `/v1/admin/*` provisioning routes |
 
 ### Email
 

--- a/docs/MARITACA_API_SPEC.md
+++ b/docs/MARITACA_API_SPEC.md
@@ -194,6 +194,78 @@ Health check (no authentication). Used for readiness/liveness.
 }
 ```
 
+## Admin API
+
+Provisioning endpoints to mint project-scoped API keys at runtime — the HTTP
+equivalent of the `create-api-key` CLI. Intended for multi-tenant consumers that
+create **one Maritaca project / API key per downstream tenant** at onboarding.
+
+Gated behind a dedicated `ADMIN_API_KEY` bearer credential, **distinct from
+project API keys**, so a normal project key cannot create or revoke keys:
+
+```
+Authorization: Bearer <ADMIN_API_KEY>
+```
+
+- `503 Service Unavailable` when `ADMIN_API_KEY` is not configured.
+- `401 Unauthorized` when the Authorization header is missing or malformed.
+- `403 Forbidden` when a bearer token is present but is not the admin key
+  (e.g. a project API key).
+
+### POST /v1/admin/api-keys
+
+Create an API key bound to a project. The plaintext key is returned **exactly
+once** and is never retrievable again (only a bcrypt hash + lookup prefix are stored).
+
+**Body**
+
+```json
+{ "projectId": "tenant-acme" }
+```
+
+**Success response**: `201`
+
+```json
+{
+  "id": "string",
+  "projectId": "string",
+  "apiKey": "maritaca_…",
+  "keyPrefix": "string (16 hex chars)",
+  "createdAt": "string ISO 8601"
+}
+```
+
+- `400 Bad Request` when `projectId` is missing or empty.
+
+### GET /v1/admin/api-keys?projectId=…
+
+List a project's API keys (metadata only — the secret is never returned).
+
+**Success response**: `200`
+
+```json
+{
+  "projectId": "string",
+  "apiKeys": [
+    { "id": "string", "projectId": "string", "keyPrefix": "string", "createdAt": "string ISO 8601" }
+  ]
+}
+```
+
+- `400 Bad Request` when the `projectId` query parameter is missing.
+
+### DELETE /v1/admin/api-keys/:id
+
+Revoke (delete) an API key by id.
+
+**Success response**: `200`
+
+```json
+{ "status": "revoked", "id": "string" }
+```
+
+- `404 Not Found` when no key matches the id.
+
 ## Rate limiting
 
 - Applied by `projectId` (authenticated requests) or by IP (when not authenticated).

--- a/docs/slack-oauth.md
+++ b/docs/slack-oauth.md
@@ -2,6 +2,19 @@
 
 Maritaca supports per-project Slack integrations via OAuth. Each project can connect its own Slack workspace — the platform handles the OAuth flow, encrypts and stores the bot token, and uses it automatically when sending messages.
 
+> **One project per tenant.** A Slack integration is scoped per `projectId`
+> (`UNIQUE(project_id, channel, provider)` → exactly one active Slack workspace
+> per project). If you are a **multi-tenant consumer** (a SaaS whose own
+> customers each need their own Slack workspace), authenticating all of them
+> with a single Maritaca API key collapses them into one project — the next
+> tenant's OAuth **overwrites** the previous workspace token. The
+> architecturally-aligned fix is **one Maritaca project / API key per downstream
+> tenant**: provision a key per tenant via `pnpm create-api-key <key> <tenant-id>`
+> or, at runtime, the admin API (`POST /v1/admin/api-keys` — see the
+> [README](../README.md#admin-api--provisioning-api-keys) and
+> [API spec](./MARITACA_API_SPEC.md#admin-api)), then run this OAuth flow with
+> each tenant's own key so every tenant gets an isolated Slack integration.
+
 ## Prerequisites
 
 - A running Maritaca instance (API + Worker + Postgres)

--- a/packages/api/src/__tests__/middleware/adminAuth.test.ts
+++ b/packages/api/src/__tests__/middleware/adminAuth.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest'
+import { verifyAdminKey, createAdminAuthOnRequestHandler } from '../../middleware/adminAuth.js'
+
+describe('verifyAdminKey', () => {
+  it('returns true for an exact match', () => {
+    expect(verifyAdminKey('s3cret-admin-key', 's3cret-admin-key')).toBe(true)
+  })
+
+  it('returns false for a mismatch of equal length', () => {
+    expect(verifyAdminKey('s3cret-admin-keX', 's3cret-admin-key')).toBe(false)
+  })
+
+  it('returns false for different-length values without throwing', () => {
+    expect(verifyAdminKey('short', 'a-much-longer-admin-secret')).toBe(false)
+  })
+
+  it('returns false when either value is empty', () => {
+    expect(verifyAdminKey('', 's3cret')).toBe(false)
+    expect(verifyAdminKey('s3cret', '')).toBe(false)
+  })
+})
+
+describe('createAdminAuthOnRequestHandler', () => {
+  it('returns a handler function', () => {
+    expect(typeof createAdminAuthOnRequestHandler()).toBe('function')
+  })
+})

--- a/packages/api/src/__tests__/routes/admin/api-keys.test.ts
+++ b/packages/api/src/__tests__/routes/admin/api-keys.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import Fastify, { FastifyInstance } from 'fastify'
+import { adminApiKeyRoutes } from '../../../routes/admin/api-keys.js'
+
+const ADMIN_KEY = 'test-admin-key-123'
+
+interface MockState {
+  listResult?: unknown[]
+  deleteResult?: unknown[]
+}
+
+/**
+ * Minimal drizzle-shaped mock that exercises the real apiKeys service.
+ * Insert echoes the inserted values; list/delete return configurable rows.
+ */
+function buildMockDb(state: MockState) {
+  return {
+    insert: () => ({
+      values: (v: { keyHash: string; keyPrefix: string; projectId: string }) => ({
+        returning: async () => [
+          {
+            id: 'key_generated',
+            projectId: v.projectId,
+            keyPrefix: v.keyPrefix,
+            createdAt: new Date('2026-01-01T00:00:00.000Z'),
+          },
+        ],
+      }),
+    }),
+    select: () => ({ from: () => ({ where: () => ({ orderBy: async () => state.listResult ?? [] }) }) }),
+    delete: () => ({ where: () => ({ returning: async () => state.deleteResult ?? [] }) }),
+  } as any
+}
+
+describe('Admin API key routes', () => {
+  let app: FastifyInstance
+  const state: MockState = {}
+  const auth = { authorization: `Bearer ${ADMIN_KEY}` }
+
+  beforeEach(async () => {
+    process.env.ADMIN_API_KEY = ADMIN_KEY
+    state.listResult = undefined
+    state.deleteResult = undefined
+    app = Fastify()
+    app.decorate('db', buildMockDb(state))
+    await app.register(adminApiKeyRoutes)
+    await app.ready()
+  })
+
+  afterEach(async () => {
+    await app.close()
+    delete process.env.ADMIN_API_KEY
+  })
+
+  // --- Auth gating ---
+
+  it('rejects requests with no Authorization header (401)', async () => {
+    const res = await app.inject({ method: 'POST', url: '/v1/admin/api-keys', payload: { projectId: 'tenant-a' } })
+    expect(res.statusCode).toBe(401)
+  })
+
+  it('rejects a normal project / wrong bearer key (403)', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/admin/api-keys',
+      headers: { authorization: 'Bearer maritaca_a_normal_project_key' },
+      payload: { projectId: 'tenant-a' },
+    })
+    expect(res.statusCode).toBe(403)
+  })
+
+  it('returns 503 when ADMIN_API_KEY is not configured', async () => {
+    delete process.env.ADMIN_API_KEY
+    const res = await app.inject({ method: 'GET', url: '/v1/admin/api-keys?projectId=tenant-a', headers: auth })
+    expect(res.statusCode).toBe(503)
+  })
+
+  // --- Create ---
+
+  it('creates a key bound to the project and returns the plaintext once (201)', async () => {
+    const res = await app.inject({ method: 'POST', url: '/v1/admin/api-keys', headers: auth, payload: { projectId: 'tenant-a' } })
+    expect(res.statusCode).toBe(201)
+    const body = res.json()
+    expect(body.id).toBe('key_generated')
+    expect(body.projectId).toBe('tenant-a')
+    expect(body.apiKey).toMatch(/^maritaca_/)
+    expect(body.keyPrefix).toMatch(/^[0-9a-f]{16}$/)
+    expect(body.createdAt).toBeDefined()
+    // never leak the stored hash
+    expect(body).not.toHaveProperty('keyHash')
+  })
+
+  it('rejects create without a projectId (400)', async () => {
+    const res = await app.inject({ method: 'POST', url: '/v1/admin/api-keys', headers: auth, payload: {} })
+    expect(res.statusCode).toBe(400)
+  })
+
+  // --- List ---
+
+  it('lists keys for a project as metadata only (200)', async () => {
+    state.listResult = [
+      { id: 'key_1', projectId: 'tenant-a', keyPrefix: 'abcd1234abcd1234', createdAt: '2026-01-01T00:00:00.000Z' },
+    ]
+    const res = await app.inject({ method: 'GET', url: '/v1/admin/api-keys?projectId=tenant-a', headers: auth })
+    expect(res.statusCode).toBe(200)
+    const body = res.json()
+    expect(body.projectId).toBe('tenant-a')
+    expect(body.apiKeys).toHaveLength(1)
+    expect(body.apiKeys[0]).not.toHaveProperty('keyHash')
+    expect(body.apiKeys[0]).not.toHaveProperty('apiKey')
+  })
+
+  it('rejects list without a projectId query (400)', async () => {
+    const res = await app.inject({ method: 'GET', url: '/v1/admin/api-keys', headers: auth })
+    expect(res.statusCode).toBe(400)
+  })
+
+  // --- Revoke ---
+
+  it('revokes an existing key (200)', async () => {
+    state.deleteResult = [{ id: 'key_1' }]
+    const res = await app.inject({ method: 'DELETE', url: '/v1/admin/api-keys/key_1', headers: auth })
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toEqual({ status: 'revoked', id: 'key_1' })
+  })
+
+  it('returns 404 when revoking a missing key', async () => {
+    state.deleteResult = []
+    const res = await app.inject({ method: 'DELETE', url: '/v1/admin/api-keys/nope', headers: auth })
+    expect(res.statusCode).toBe(404)
+  })
+})

--- a/packages/api/src/__tests__/services/apiKeys.test.ts
+++ b/packages/api/src/__tests__/services/apiKeys.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from 'vitest'
+import bcrypt from 'bcrypt'
+import { createApiKey, listApiKeys, revokeApiKey, generateKeyPrefix } from '../../services/apiKeys.js'
+
+describe('generateKeyPrefix', () => {
+  it('returns the first 16 chars of the SHA-256 hex digest', () => {
+    expect(generateKeyPrefix('maritaca_abc')).toMatch(/^[0-9a-f]{16}$/)
+  })
+
+  it('is deterministic for the same input', () => {
+    expect(generateKeyPrefix('x')).toBe(generateKeyPrefix('x'))
+  })
+})
+
+describe('createApiKey', () => {
+  it('stores a bcrypt hash + lookup prefix bound to the project and returns the plaintext once', async () => {
+    let inserted: { keyHash: string; keyPrefix: string; projectId: string } | undefined
+    const db = {
+      insert: () => ({
+        values: (v: { keyHash: string; keyPrefix: string; projectId: string }) => {
+          inserted = v
+          return {
+            returning: async () => [
+              {
+                id: 'key_1',
+                projectId: v.projectId,
+                keyPrefix: v.keyPrefix,
+                createdAt: new Date('2026-01-01T00:00:00.000Z'),
+              },
+            ],
+          }
+        },
+      }),
+    } as any
+
+    const result = await createApiKey(db, 'tenant-a')
+
+    expect(result.id).toBe('key_1')
+    expect(result.projectId).toBe('tenant-a')
+    expect(result.apiKey).toMatch(/^maritaca_/)
+    expect(result.keyPrefix).toBe(generateKeyPrefix(result.apiKey))
+    expect(result.createdAt).toEqual(new Date('2026-01-01T00:00:00.000Z'))
+
+    // The stored hash is a bcrypt hash of the plaintext, not the plaintext itself.
+    expect(inserted?.projectId).toBe('tenant-a')
+    expect(inserted?.keyHash).not.toBe(result.apiKey)
+    expect(await bcrypt.compare(result.apiKey, inserted!.keyHash)).toBe(true)
+  })
+})
+
+describe('listApiKeys', () => {
+  it('selects project-scoped metadata ordered by createdAt desc', async () => {
+    const rows = [{ id: 'key_2', projectId: 'tenant-a', keyPrefix: 'abcd1234abcd1234', createdAt: new Date() }]
+    const orderBy = vi.fn(async () => rows)
+    const where = vi.fn(() => ({ orderBy }))
+    const from = vi.fn(() => ({ where }))
+    const select = vi.fn(() => ({ from }))
+    const db = { select } as any
+
+    const result = await listApiKeys(db, 'tenant-a')
+
+    expect(result).toBe(rows)
+    expect(select).toHaveBeenCalledOnce()
+    expect(orderBy).toHaveBeenCalledOnce()
+  })
+})
+
+describe('revokeApiKey', () => {
+  it('returns true when a row is deleted', async () => {
+    const db = { delete: () => ({ where: () => ({ returning: async () => [{ id: 'key_3' }] }) }) } as any
+    expect(await revokeApiKey(db, 'key_3')).toBe(true)
+  })
+
+  it('returns false when no row matches', async () => {
+    const db = { delete: () => ({ where: () => ({ returning: async () => [] }) }) } as any
+    expect(await revokeApiKey(db, 'nope')).toBe(false)
+  })
+})

--- a/packages/api/src/middleware/adminAuth.ts
+++ b/packages/api/src/middleware/adminAuth.ts
@@ -1,0 +1,67 @@
+import { FastifyReply, FastifyRequest } from 'fastify'
+import { createHash, timingSafeEqual } from 'crypto'
+
+/**
+ * Admin authentication for provisioning routes (/v1/admin/*).
+ *
+ * Gated behind a dedicated `ADMIN_API_KEY` credential, distinct from project
+ * API keys, so a normal project key cannot mint or revoke keys for other
+ * projects. The project-key auth hook (middleware/auth.ts) skips /v1/admin/*;
+ * this hook is registered inside the admin routes plugin so it only guards
+ * admin routes (Fastify encapsulation keeps it from affecting sibling routes).
+ */
+
+/**
+ * Constant-time comparison of a provided credential against the expected one.
+ * Hashes both to a fixed length first so the comparison never leaks length and
+ * timingSafeEqual never throws on mismatched buffer sizes.
+ */
+export function verifyAdminKey(provided: string, expected: string): boolean {
+  if (!provided || !expected) return false
+  const a = createHash('sha256').update(provided).digest()
+  const b = createHash('sha256').update(expected).digest()
+  return timingSafeEqual(a, b)
+}
+
+/**
+ * Creates the onRequest handler enforcing admin authentication.
+ * - 503 when `ADMIN_API_KEY` is not configured (admin API disabled).
+ * - 401 when the Authorization header is missing or malformed.
+ * - 403 when a Bearer token is present but does not match (e.g. a project key).
+ */
+export function createAdminAuthOnRequestHandler(): (
+  request: FastifyRequest,
+  reply: FastifyReply,
+) => Promise<void> {
+  return async (request: FastifyRequest, reply: FastifyReply) => {
+    const adminKey = process.env.ADMIN_API_KEY
+
+    if (!adminKey) {
+      request.log.warn({ url: request.url }, '[admin-auth] 503: ADMIN_API_KEY not configured')
+      return reply.code(503).send({
+        error: 'Service Unavailable',
+        message: 'Admin API is not configured (ADMIN_API_KEY missing)',
+      })
+    }
+
+    const authHeader = request.headers.authorization
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+      request.log.info({ url: request.url }, '[admin-auth] 401: missing or invalid Authorization header')
+      return reply.code(401).send({
+        error: 'Unauthorized',
+        message: 'Missing or invalid Authorization header',
+      })
+    }
+
+    const provided = authHeader.substring(7) // Remove 'Bearer ' prefix
+    if (!verifyAdminKey(provided, adminKey)) {
+      request.log.info({ url: request.url }, '[admin-auth] 403: invalid admin credentials')
+      return reply.code(403).send({
+        error: 'Forbidden',
+        message: 'Invalid admin credentials',
+      })
+    }
+
+    request.log.debug({ url: request.url }, '[admin-auth] OK')
+  }
+}

--- a/packages/api/src/middleware/auth.ts
+++ b/packages/api/src/middleware/auth.ts
@@ -44,6 +44,11 @@ export function createAuthOnRequestHandler(): (request: FastifyRequest, reply: i
     if (request.url.startsWith('/v1/integrations/slack/callback')) {
       return
     }
+    // Admin routes use a separate ADMIN_API_KEY credential, enforced by the
+    // admin routes plugin's own onRequest hook (see middleware/adminAuth.ts).
+    if (request.url.startsWith('/v1/admin/')) {
+      return
+    }
 
     const authHeader = request.headers.authorization
 

--- a/packages/api/src/routes/admin/api-keys.ts
+++ b/packages/api/src/routes/admin/api-keys.ts
@@ -1,0 +1,77 @@
+import { FastifyPluginAsync } from 'fastify'
+import { createAdminAuthOnRequestHandler } from '../../middleware/adminAuth.js'
+import { createApiKey, listApiKeys, revokeApiKey } from '../../services/apiKeys.js'
+
+/**
+ * Admin API key provisioning routes (/v1/admin/api-keys).
+ *
+ * Lets multi-tenant consumers mint one Maritaca project / API key per
+ * downstream tenant at onboarding, instead of the manual create-api-key CLI.
+ * Gated behind ADMIN_API_KEY (see middleware/adminAuth.ts). The admin-auth hook
+ * is added inside this plugin so Fastify encapsulation scopes it to these
+ * routes only; the global project-key auth hook skips /v1/admin/*.
+ */
+export const adminApiKeyRoutes: FastifyPluginAsync = async (fastify) => {
+  if (!process.env.ADMIN_API_KEY) {
+    fastify.log.warn('ADMIN_API_KEY is not set; admin API (/v1/admin/*) will reject all requests with 503')
+  }
+
+  fastify.addHook('onRequest', createAdminAuthOnRequestHandler())
+
+  /**
+   * POST /v1/admin/api-keys
+   * Create an API key bound to a project. Returns the plaintext key exactly once.
+   */
+  fastify.post<{ Body: { projectId?: unknown } }>('/v1/admin/api-keys', async (request, reply) => {
+    const body = (request.body ?? {}) as { projectId?: unknown }
+    const projectId = typeof body.projectId === 'string' ? body.projectId.trim() : ''
+
+    if (!projectId) {
+      return reply.code(400).send({
+        error: 'Bad Request',
+        message: 'projectId is required',
+      })
+    }
+
+    const created = await createApiKey(request.server.db, projectId)
+    request.log.info({ id: created.id, projectId: created.projectId }, '[admin] API key created')
+    return reply.code(201).send(created)
+  })
+
+  /**
+   * GET /v1/admin/api-keys?projectId=…
+   * List API keys for a project (metadata only — never the secret).
+   */
+  fastify.get<{ Querystring: { projectId?: string } }>('/v1/admin/api-keys', async (request, reply) => {
+    const projectId = (request.query.projectId ?? '').trim()
+
+    if (!projectId) {
+      return reply.code(400).send({
+        error: 'Bad Request',
+        message: 'projectId query parameter is required',
+      })
+    }
+
+    const keys = await listApiKeys(request.server.db, projectId)
+    return reply.send({ projectId, apiKeys: keys })
+  })
+
+  /**
+   * DELETE /v1/admin/api-keys/:id
+   * Revoke (delete) an API key by id.
+   */
+  fastify.delete<{ Params: { id: string } }>('/v1/admin/api-keys/:id', async (request, reply) => {
+    const { id } = request.params
+
+    const revoked = await revokeApiKey(request.server.db, id)
+    if (!revoked) {
+      return reply.code(404).send({
+        error: 'Not Found',
+        message: `No API key found with id: ${id}`,
+      })
+    }
+
+    request.log.info({ id }, '[admin] API key revoked')
+    return reply.send({ status: 'revoked', id })
+  })
+}

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -13,6 +13,7 @@ import {
 import { messageRoutes } from './routes/messages.js'
 import { resendWebhookRoutes } from './routes/webhooks/resend.js'
 import { slackIntegrationRoutes } from './routes/integrations/slack.js'
+import { adminApiKeyRoutes } from './routes/admin/api-keys.js'
 import { createAuthOnRequestHandler } from './middleware/auth.js'
 import { createQueue } from './services/queue.js'
 
@@ -140,6 +141,7 @@ export async function createServer(options: ServerOptions): Promise<FastifyInsta
   await server.register(messageRoutes)
   await server.register(resendWebhookRoutes)
   await server.register(slackIntegrationRoutes)
+  await server.register(adminApiKeyRoutes)
 
   // Track health status for metrics
   let currentHealthStatus = 1 // 1 = healthy, 0 = degraded

--- a/packages/api/src/services/apiKeys.ts
+++ b/packages/api/src/services/apiKeys.ts
@@ -1,0 +1,91 @@
+import bcrypt from 'bcrypt'
+import { createHash } from 'crypto'
+import { createId } from '@paralleldrive/cuid2'
+import { eq, desc } from 'drizzle-orm'
+import { apiKeys, type DbClient } from '@maritaca/core'
+
+/**
+ * API key provisioning service.
+ *
+ * Mirrors the CLI scripts (scripts/create-api-key.ts, list-api-keys.ts,
+ * remove-api-key.ts) so keys can be minted programmatically at runtime via the
+ * admin HTTP API. Kept framework-agnostic (takes a DbClient) so it can be unit
+ * tested without a running server.
+ */
+
+/** bcrypt cost factor; matches scripts/create-api-key.ts */
+const BCRYPT_ROUNDS = 10
+
+/**
+ * Generate a prefix for fast API key lookup.
+ * Uses the first 16 characters of the SHA-256 hash (matches auth middleware).
+ */
+export function generateKeyPrefix(apiKey: string): string {
+  return createHash('sha256').update(apiKey).digest('hex').substring(0, 16)
+}
+
+export interface CreatedApiKey {
+  id: string
+  projectId: string
+  /** Plaintext API key — returned exactly once, never stored or retrievable again. */
+  apiKey: string
+  keyPrefix: string
+  createdAt: Date
+}
+
+/**
+ * Create a new API key bound to a project.
+ * Generates a random `maritaca_<cuid>` key, stores its bcrypt hash + lookup
+ * prefix, and returns the plaintext value once.
+ */
+export async function createApiKey(db: DbClient, projectId: string): Promise<CreatedApiKey> {
+  const apiKeyValue = `maritaca_${createId()}`
+  const keyHash = await bcrypt.hash(apiKeyValue, BCRYPT_ROUNDS)
+  const keyPrefix = generateKeyPrefix(apiKeyValue)
+
+  const [row] = await db
+    .insert(apiKeys)
+    .values({ keyHash, keyPrefix, projectId })
+    .returning()
+
+  return {
+    id: row.id,
+    projectId: row.projectId,
+    apiKey: apiKeyValue,
+    keyPrefix: row.keyPrefix,
+    createdAt: row.createdAt,
+  }
+}
+
+export interface ApiKeyMetadata {
+  id: string
+  projectId: string
+  keyPrefix: string
+  createdAt: Date
+}
+
+/**
+ * List API keys for a project (metadata only — the secret is never stored and
+ * cannot be returned).
+ */
+export async function listApiKeys(db: DbClient, projectId: string): Promise<ApiKeyMetadata[]> {
+  return db
+    .select({
+      id: apiKeys.id,
+      projectId: apiKeys.projectId,
+      keyPrefix: apiKeys.keyPrefix,
+      createdAt: apiKeys.createdAt,
+    })
+    .from(apiKeys)
+    .where(eq(apiKeys.projectId, projectId))
+    .orderBy(desc(apiKeys.createdAt))
+}
+
+/**
+ * Revoke (delete) an API key by id.
+ * Returns true if a row was deleted, false if no key matched.
+ */
+export async function revokeApiKey(db: DbClient, id: string): Promise<boolean> {
+  const deleted = await db.delete(apiKeys).where(eq(apiKeys.id, id)).returning({ id: apiKeys.id })
+  return deleted.length > 0
+}


### PR DESCRIPTION
Closes #39.

## What

Adds an **admin-authenticated** HTTP API to provision project-scoped API keys at runtime — the automatable equivalent of the `create-api-key` CLI:

| Endpoint | Description |
|----------|-------------|
| `POST /v1/admin/api-keys` | Create a key bound to `projectId`; returns the plaintext key **exactly once** (`{ id, projectId, apiKey, keyPrefix, createdAt }`) |
| `GET /v1/admin/api-keys?projectId=…` | List a project's keys (metadata only — never the secret) |
| `DELETE /v1/admin/api-keys/:id` | Revoke a key (`404` if not found) |

## Why

Multi-tenant downstream consumers (e.g. Sunshine) authenticate with a single Maritaca API key, so all their tenants collapse into one `projectId` → one Slack integration, and each new tenant's OAuth overwrites the previous workspace token. The architecturally-aligned fix is **one Maritaca project / API key per downstream tenant** — this makes that provisionable at onboarding instead of only via the manual CLI.

## Auth model

Gated behind a dedicated `ADMIN_API_KEY` bearer credential, **distinct from project API keys**, so a normal project key cannot mint or revoke keys:

- `503` when `ADMIN_API_KEY` is unset (admin API disabled by default)
- `401` when the `Authorization` header is missing/malformed
- `403` when a bearer token is present but is not the admin key (e.g. a project key)

The constant-time comparison hashes both sides to a fixed length (`timingSafeEqual` never throws / leaks length). The global project-key auth hook skips `/v1/admin/*`; the admin-auth hook lives inside the admin routes plugin so Fastify encapsulation scopes it to those routes only.

## Tests

- `services/apiKeys.test.ts` — create (bcrypt hash + prefix, plaintext returned once), list, revoke
- `middleware/adminAuth.test.ts` — `verifyAdminKey` (match / mismatch / length / empty)
- `routes/admin/api-keys.test.ts` — full route coverage via `inject`: create/list/revoke, `400` validation, `404`, and auth rejection (`401` / `403` / `503`)

Full workspace `typecheck`, `test` (274 tests), and `build` pass.

## Docs

- `README.md` — Admin API section + `ADMIN_API_KEY` env row
- `docs/MARITACA_API_SPEC.md` — endpoint reference
- `.env.example` — `ADMIN_API_KEY` with generation hint
- `docs/slack-oauth.md` — cross-links the "one project per tenant" pattern

## Acceptance criteria

- [x] `POST` creates an `api_keys` row bound to `projectId` (bcrypt `keyHash` + `keyPrefix`), returns the plaintext key once
- [x] Admin-auth required; unauthenticated / normal-project-key requests rejected (`401`/`403`)
- [x] `GET` lists keys for a project (no secret); `DELETE` revokes
- [x] Tests cover create/list/revoke + auth rejection
- [x] Documented (README / docs), and `docs/slack-oauth.md` cross-links the "one project per tenant" pattern

## Non-goals (unchanged)

No `projects` table, no project metadata/quotas, no UI, no self-serve signup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)