### PR TITLE
ci: run Docker actions on Node.js 24 LTS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,11 @@ concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  # Run JavaScript actions (e.g. docker/setup-buildx-action, docker/build-push-action)
+  # on Node.js 24 LTS instead of the deprecated Node.js 20 bundled runtime.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build-test:
     name: typecheck · test · build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,9 @@ on:
 
 env:
   REGISTRY: ghcr.io
+  # Run JavaScript actions (e.g. docker/setup-buildx-action, docker/build-push-action)
+  # on Node.js 24 LTS instead of the deprecated Node.js 20 bundled runtime.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   build-and-push:


### PR DESCRIPTION
## What

Forces JavaScript-based GitHub Actions (notably the Docker actions — `docker/setup-buildx-action`, `docker/build-push-action`, `docker/login-action`, `docker/metadata-action`) to run on the **Node.js 24 LTS** runtime instead of the deprecated Node.js 20 bundled runtime, via a workflow-level `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` in both `ci.yml` and `deploy.yml`.

## Why

The last production deploy surfaced this annotation:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: `docker/build-push-action@v6`, `docker/setup-buildx-action@v3`. … Actions will be forced to run with Node.js 24 by default starting June 16th, 2026.

These are third-party actions, so their `action.yml` runtime can't be edited directly. `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` is the opt-in documented in the warning itself, and the env-var route forces them onto Node 24 now (ahead of GitHub's June 16th default flip).

## Verification

This PR's CI run includes the `docker build (no push)` jobs, which use the Docker actions — a clean run with no Node 20 deprecation annotation confirms the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)