### PR TITLE
chore(release): bump version to 1.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maritaca",
-  "version": "1.2.0",
+  "version": "1.3.1",
   "description": "Self-hosted, event-oriented notification API for multi-channel notifications",
   "private": true,
   "type": "module",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maritaca/api",
-  "version": "1.2.0",
+  "version": "1.3.1",
   "description": "Fastify HTTP API server for Maritaca",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maritaca/core",
-  "version": "1.2.0",
+  "version": "1.3.1",
   "description": "Core types, validation, and provider interfaces for Maritaca",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maritaca/sdk",
-  "version": "1.2.0",
+  "version": "1.3.1",
   "description": "TypeScript SDK for Maritaca notification API",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maritaca/worker",
-  "version": "1.2.0",
+  "version": "1.3.1",
   "description": "BullMQ worker for processing Maritaca notifications",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## What
Bump all monorepo `package.json` versions from `1.2.0` to `1.3.1`.

## Why
The package.json versions had drifted: the deploy flow advances via git tags (currently `v1.3.0` + 2 commits), while `package.json` was stuck at `1.2.0`. This realigns the static metadata with the upcoming `v1.3.1` release tag.

This is metadata only — the **running** version is reported by the API `GET /version` endpoint from `APP_VERSION` / `COMMIT_SHA`, which are injected from the git tag at Docker build time (`deploy.yml`). It does not read `package.json`.

## Follow-up
After merge, tag the merge commit `v1.3.1` and push it to trigger the production deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)