### PR TITLE
chore: gitignore docker-compose.override.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ Thumbs.db
 
 # Docker
 .dockerignore
+docker-compose.override.yml


### PR DESCRIPTION
Adds `docker-compose.override.yml` to `.gitignore`.

The local dev setup uses a gitignored override to point the api/worker
containers at a host Redis instance (bundled redis disabled). This keeps that
machine-specific file out of version control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)